### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ torch
 kornia
 einops
 tokenizers
-transformers
+transformers==4.20.0  


### PR DESCRIPTION
ImportError: cannot import name 'checkpoint' from 'transformers.models.t5.modeling_t5'
Mentioned in Issue 47 [https://github.com/vimalabs/VIMA/issues/47](https://github.com/vimalabs/VIMA/issues/47)
`transformers==4.20.0` is working well for this bug.

